### PR TITLE
Fixed LocalWindowShare API for screenshare

### DIFF
--- a/projects/video-client/src/lib/video-client.service.ts
+++ b/projects/video-client/src/lib/video-client.service.ts
@@ -417,7 +417,7 @@ export class VideoClientService {
                         this._vidyoClient.getConnectState()
                             .then(_status => {
                                 if (_status.webrtc) {
-                                    this._vidyoConnector.SelectLocalWindowShare(localWindowShare)
+                                    this._vidyoConnector.SelectLocalWindowShare({ localWindowShare:localWindowShare })
                                         .then(() => {
                                             console.log('video:registerLocalWindowShareEvents.onAdded.SelectLocalWindowShare(): success');
                                             const evt: WindowShareEvent = { type: 'added', windowShare: localWindowShare };


### PR DESCRIPTION
It fixes the screen share issue on existing library. 
Root Cause :  Function signature was changed in newer version of vidyo client.